### PR TITLE
Surface interesting dependent projects

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -97,6 +97,31 @@ class Collection < ApplicationRecord
     projects.select{|p| p.committers_names.include?(name) }
   end
 
+
+  def interesting_dependent_repos(limit: 30)
+    collection_urls = projects.pluck(:url).compact.map(&:downcase).to_set
+    candidates = {}
+
+    projects.where.not(dependent_repos: nil).find_each do |project|
+      Array(project.dependent_repos).each do |repo|
+        next unless repo.is_a?(Hash)
+
+        url = repo['html_url'] || repo['url']
+        next if url.blank?
+        next if collection_urls.include?(url.downcase)
+
+        candidates[url] ||= repo.merge('seen_count' => 0, 'dependency_sources' => [])
+        candidates[url]['seen_count'] += 1
+        candidates[url]['dependency_sources'] << project.url
+        candidates[url]['score'] = [candidates[url]['score'].to_f, repo['score'].to_f].max
+      end
+    end
+
+    candidates.values.sort_by { |repo|
+      [repo['score'].to_f, repo['seen_count'].to_i, repo['stargazers_count'].to_i]
+    }.reverse.first(limit)
+  end
+
   def dependencies
     deps = projects.map(&:dependency_packages).flatten(1)
     deps.group_by(&:itself).transform_values(&:count).sort_by{|k,v| v}.reverse

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -108,6 +108,28 @@
           </div>
         </div>
 
+        <% interesting_dependents = @collection.interesting_dependent_repos %>
+        <% if interesting_dependents.any? %>
+          <div class='card mb-3'>
+            <div class="card-header">
+              Interesting dependent projects
+            </div>
+            <div class="list-group list-group-flush">
+              <% interesting_dependents.each do |repo| %>
+                <a class="list-group-item list-group-item-action d-flex justify-content-between align-items-center" href="<%= repo['html_url'] || repo['url'] %>" target="_blank">
+                  <span>
+                    <%= repo['full_name'] || repo['name'] || repo['html_url'] || repo['url'] %>
+                    <small class="text-muted d-block">
+                      Used by <%= pluralize(repo['seen_count'], 'collection project') %>
+                    </small>
+                  </span>
+                  <span class="badge bg-primary rounded-pill"><%= number_with_delimiter repo['score'].to_i %></span>
+                </a>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
+
         <div class='card mb-3'>
           <div class="card-header">
             Repository Owners


### PR DESCRIPTION
Refs #17

Adds an "Interesting dependent projects" section to collection pages.

Changes:
- Aggregates `dependent_repos` already fetched for collection projects
- Excludes repositories already present in the collection
- Deduplicates candidates by repository URL
- Ranks candidates by score, number of collection projects that depend on them, and stars
- Shows the top candidates in the collection sidebar with links and source counts

Validation:
- `ruby -c app/models/collection.rb`
- `ruby -rerb -e 'ERB.new(File.read("app/views/collections/show.html.erb")).src'`
- `git diff --check`

Notes:
- Full Rails test execution is locally blocked by the repo lockfile requiring Bundler 4.0.10 under system Ruby: `Could not find 'bundler' (4.0.10)`.