### PR TITLE
Create collections from keywords

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -134,6 +134,40 @@ class Collection < ApplicationRecord
     combined_hash.sort_by{|k,v| v}.reverse
   end
 
+
+  def import_keywords(keywords, limit: 300)
+    urls = keywords.flat_map do |keyword|
+      keyword = keyword.to_s.strip
+      next [] if keyword.blank?
+
+      keyword_package_urls(keyword) + topic_repository_urls(keyword)
+    end
+
+    urls.compact_blank.uniq.first(limit).each do |url|
+      puts url
+      project = projects.find_or_create_by(url: url)
+      project.sync_async unless project.last_synced_at.present?
+    end
+  end
+
+  def keyword_package_urls(keyword)
+    conn = build_faraday_connection("https://packages.ecosyste.ms/api/v1/keywords/#{keyword}?per_page=1000")
+    resp = conn.get
+    return [] unless resp.status == 200
+
+    data = JSON.parse(resp.body)
+    data['packages'].reject { |package| package['status'].present? }.map { |package| package['repository_url'] }
+  end
+
+  def topic_repository_urls(topic)
+    conn = build_faraday_connection("https://repos.ecosyste.ms/api/v1/topics/#{topic}?per_page=1000")
+    resp = conn.get
+    return [] unless resp.status == 200
+
+    data = JSON.parse(resp.body)
+    data['repositories'].map { |repository| repository['html_url'] }
+  end
+
   def import_keyword(keyword)
     conn = build_faraday_connection("https://packages.ecosyste.ms/api/v1/keywords/#{keyword}?per_page=1000")
     resp = conn.get
@@ -200,6 +234,10 @@ class Collection < ApplicationRecord
   def import_tag(tag)
     import_keyword(tag)
     import_topic(tag)
+  end
+
+  def import_tags(tags, limit: 300)
+    import_keywords(Array(tags), limit: limit)
   end
 
   def remove_duplicate_projects

--- a/lib/tasks/collections.rake
+++ b/lib/tasks/collections.rake
@@ -1,0 +1,17 @@
+namespace :collections do
+  desc 'Create a collection from comma-separated keywords/topics'
+  task :from_keywords, [:name, :keywords, :limit] => :environment do |_task, args|
+    abort 'Usage: rails collections:from_keywords[name,keyword1 keyword2,300]' if args[:name].blank? || args[:keywords].blank?
+
+    keywords = args[:keywords].split(/[,
+]/).map(&:strip).reject(&:blank?)
+    limit = args[:limit].presence&.to_i || 300
+    collection = Collection.find_or_create_by!(name: args[:name]) do |new_collection|
+      new_collection.url = "keywords:#{keywords.join(',')}"
+    end
+
+    collection.update!(url: "keywords:#{keywords.join(',')}") if collection.url.blank?
+    collection.import_keywords(keywords, limit: limit)
+    puts "Imported #{collection.projects.count} projects into #{collection.name}"
+  end
+end


### PR DESCRIPTION
Refs #12

Adds a direct way to create/populate a collection from multiple keywords/topics.

Changes:
- Adds `Collection#import_keywords` to combine package keyword results and repository topic results
- Deduplicates repository URLs across all requested keywords/topics
- Caps imported projects with a configurable limit, defaulting to 300
- Keeps existing async project sync behavior for newly imported projects
- Adds `collections:from_keywords[name,keywords,limit]` rake task for one-shot collection creation/import

Validation:
- `ruby -c app/models/collection.rb`
- `ruby -c lib/tasks/collections.rake`
- `git diff --check`

Notes:
- Full Rails tests are locally blocked by the repo lockfile requiring Bundler 4.0.10 under system Ruby.